### PR TITLE
remove RTL stlyes from production build

### DIFF
--- a/webpack/webpack.prod.config.js
+++ b/webpack/webpack.prod.config.js
@@ -9,8 +9,6 @@ const HtmlWebpackNewRelicPlugin = require('html-webpack-new-relic-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
-const WebpackRTLPlugin = require('webpack-rtl-plugin');
-
 module.exports = Merge.smart(commonConfig, {
   mode: 'production',
   devtool: 'source-map',
@@ -120,9 +118,6 @@ module.exports = Merge.smart(commonConfig, {
     // Writes the extracted CSS from each entry to a file in the output directory.
     new MiniCssExtractPlugin({
       filename: '[name].[chunkhash].css',
-    }),
-    new WebpackRTLPlugin({
-      filename: '[name].[contenthash].rtl.css',
     }),
     // Generates an HTML file in the output directory.
     new HtmlWebpackPlugin({


### PR DESCRIPTION
because this app is not translated at all, and this being in-place
prevents us from upgrading libraries which depend on more up-to-date
versions of @edx/frontend-i18n

JIRA:PROD-816

For @abutterworth: In prod the RTL styles were applying because the page's webpack config (which we didn't touch) was coupled to some details in the i18n code that we ripped out in favor of the library (specifically [this line](https://github.com/edx/frontend-app-program-manager/pull/11/files#diff-1aad843ea1834f047a3bc378e8f15bc2L86)). So we need to rip out those bits of the webpack config to prevent it from loading two versions of the stylesheet, since we won't under any circumstances disable any stylesheets with the latest version of the edx/frontend-i18n library.