### PR TITLE
Load programs based on read-metadata access.

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -286,7 +286,7 @@ const mapStateToProps = state => ({
   // which also means we're ready to display something.
   ready: state.userAccount.loaded || state.userAccount.error != null,
   configuration: state.configuration,
-  avatar: state.userAccount.profileImage.hasImage
+  avatar: state.userAccount.profileImage && state.userAccount.profileImage.hasImage
     ? state.userAccount.profileImage.imageUrlMedium
     : null,
 });

--- a/src/upload/UploadPage.jsx
+++ b/src/upload/UploadPage.jsx
@@ -4,12 +4,12 @@ import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
 import { StatusAlert } from '@edx/paragon';
 
-import { fetchWritablePrograms, uploadEnrollments, downloadEnrollments, removeBanner } from './actions';
+import { fetchPrograms, uploadEnrollments, downloadEnrollments, removeBanner } from './actions';
 import { uploadSelector } from './selectors';
 
 export class UploadPage extends React.Component {
   componentDidMount() {
-    this.props.fetchWritablePrograms();
+    this.props.fetchPrograms();
   }
 
   handleUploadProgramEnrollments(programKey, e) {
@@ -104,7 +104,7 @@ UploadPage.propTypes = {
     programTitle: PropTypes.string,
     programUrl: PropTypes.string,
   })).isRequired,
-  fetchWritablePrograms: PropTypes.func.isRequired,
+  fetchPrograms: PropTypes.func.isRequired,
   programBanners: PropTypes.shape().isRequired,
   uploadEnrollments: PropTypes.func.isRequired,
   downloadEnrollments: PropTypes.func.isRequired,
@@ -112,7 +112,7 @@ UploadPage.propTypes = {
 };
 
 export default connect(uploadSelector, {
-  fetchWritablePrograms,
+  fetchPrograms,
   uploadEnrollments,
   downloadEnrollments,
   removeBanner,

--- a/src/upload/UploadPage.test.jsx
+++ b/src/upload/UploadPage.test.jsx
@@ -10,7 +10,7 @@ describe('UploadPage...', () => {
       authorized
       data={[]}
       downloadEnrollments={() => {}}
-      fetchWritablePrograms={() => {}}
+      fetchPrograms={() => {}}
       programBanners={{}}
       uploadEnrollments={() => {}}
       removeBanner={() => {}}
@@ -23,7 +23,7 @@ describe('UploadPage...', () => {
       authorized={false}
       data={[]}
       downloadEnrollments={() => {}}
-      fetchWritablePrograms={() => {}}
+      fetchPrograms={() => {}}
       programBanners={{}}
       uploadEnrollments={() => {}}
       removeBanner={() => {}}
@@ -50,7 +50,7 @@ describe('UploadPage...', () => {
       authorized
       data={apiData}
       downloadEnrollments={() => {}}
-      fetchWritablePrograms={() => {}}
+      fetchPrograms={() => {}}
       programBanners={{}}
       uploadEnrollments={() => {}}
       removeBanner={() => {}}
@@ -98,7 +98,7 @@ describe('UploadPage...', () => {
       authorized
       data={apiData}
       downloadEnrollments={() => {}}
-      fetchWritablePrograms={() => {}}
+      fetchPrograms={() => {}}
       programBanners={programBanners}
       uploadEnrollments={() => {}}
       removeBanner={() => {}}
@@ -113,7 +113,7 @@ describe('UploadPage...', () => {
     wrapper.unmount();
   });
 
-  it('...calls the fetchWritablePrograms function on pageload', () => {
+  it('...calls the fetchPrograms function on pageload', () => {
     const mock = jest.fn();
 
     expect(mock).not.toHaveBeenCalled();
@@ -122,7 +122,7 @@ describe('UploadPage...', () => {
       authorized
       data={[]}
       downloadEnrollments={() => {}}
-      fetchWritablePrograms={mock}
+      fetchPrograms={mock}
       programBanners={{}}
       uploadEnrollments={() => {}}
       removeBanner={() => {}}
@@ -148,7 +148,7 @@ describe('UploadPage...', () => {
       authorized
       data={apiData}
       downloadEnrollments={mock}
-      fetchWritablePrograms={() => {}}
+      fetchPrograms={() => {}}
       programBanners={{}}
       uploadEnrollments={() => {}}
       removeBanner={() => {}}
@@ -192,7 +192,7 @@ describe('UploadPage...', () => {
       authorized
       data={apiData}
       downloadEnrollments={() => {}}
-      fetchWritablePrograms={() => {}}
+      fetchPrograms={() => {}}
       programBanners={{}}
       uploadEnrollments={mock}
       removeBanner={() => {}}

--- a/src/upload/actions.js
+++ b/src/upload/actions.js
@@ -2,25 +2,25 @@ import { utils } from '../common';
 
 const { AsyncActionType } = utils;
 
-export const FETCH_WRITABLE_PROGRAMS = new AsyncActionType('GET', 'FETCH_WRITABLE_PROGRAMS');
+export const FETCH_PROGRAMS = new AsyncActionType('GET', 'FETCH_PROGRAMS');
 
-export const fetchWritablePrograms = () => ({
-  type: FETCH_WRITABLE_PROGRAMS.BASE,
+export const fetchPrograms = () => ({
+  type: FETCH_PROGRAMS.BASE,
 });
 
-export const fetchWritableProgramsBegin = () => ({
-  type: FETCH_WRITABLE_PROGRAMS.BEGIN,
+export const fetchProgramsBegin = () => ({
+  type: FETCH_PROGRAMS.BEGIN,
 });
 
-export const fetchWritableProgramsSuccess = data => ({
-  type: FETCH_WRITABLE_PROGRAMS.SUCCESS,
+export const fetchProgramsSuccess = data => ({
+  type: FETCH_PROGRAMS.SUCCESS,
   payload: {
     data,
   },
 });
 
-export const fetchWritableProgramsFailure = error => ({
-  type: FETCH_WRITABLE_PROGRAMS.FAILURE,
+export const fetchProgramsFailure = error => ({
+  type: FETCH_PROGRAMS.FAILURE,
   payload: { error },
 });
 

--- a/src/upload/actions.test.js
+++ b/src/upload/actions.test.js
@@ -5,10 +5,10 @@ import {
   fetchJobsBegin,
   fetchJobsFailure,
   fetchJobsSuccess,
-  fetchWritablePrograms,
-  fetchWritableProgramsBegin,
-  fetchWritableProgramsFailure,
-  fetchWritableProgramsSuccess,
+  fetchPrograms,
+  fetchProgramsBegin,
+  fetchProgramsFailure,
+  fetchProgramsSuccess,
   notAuthenticated,
   pollJob,
   pollJobFailure,
@@ -64,25 +64,25 @@ describe('#DOWNLOAD_ENROLLMENTS', () => {
   });
 });
 
-describe('#FETCH_WRITABLE_PROGRAMS', () => {
+describe('#FETCH_PROGRAMS', () => {
   it('...has a base action creator', () => {
-    expect(fetchWritablePrograms).toBeInstanceOf(Function);
-    expect(fetchWritablePrograms()).toEqual({
-      type: 'GET__FETCH_WRITABLE_PROGRAMS',
+    expect(fetchPrograms).toBeInstanceOf(Function);
+    expect(fetchPrograms()).toEqual({
+      type: 'GET__FETCH_PROGRAMS',
     });
   });
 
   it('...has a begin action creator', () => {
-    expect(fetchWritableProgramsBegin).toBeInstanceOf(Function);
-    expect(fetchWritableProgramsBegin()).toEqual({
-      type: 'GET__FETCH_WRITABLE_PROGRAMS__BEGIN',
+    expect(fetchProgramsBegin).toBeInstanceOf(Function);
+    expect(fetchProgramsBegin()).toEqual({
+      type: 'GET__FETCH_PROGRAMS__BEGIN',
     });
   });
 
   it('...has a success action creator', () => {
-    expect(fetchWritableProgramsSuccess).toBeInstanceOf(Function);
-    expect(fetchWritableProgramsSuccess({ foo: 'bar' })).toEqual({
-      type: 'GET__FETCH_WRITABLE_PROGRAMS__SUCCESS',
+    expect(fetchProgramsSuccess).toBeInstanceOf(Function);
+    expect(fetchProgramsSuccess({ foo: 'bar' })).toEqual({
+      type: 'GET__FETCH_PROGRAMS__SUCCESS',
       payload: {
         data: { foo: 'bar' },
       },
@@ -90,9 +90,9 @@ describe('#FETCH_WRITABLE_PROGRAMS', () => {
   });
 
   it('...has a failure action creator', () => {
-    expect(fetchWritableProgramsFailure).toBeInstanceOf(Function);
-    expect(fetchWritableProgramsFailure({ foo: 'bar' })).toEqual({
-      type: 'GET__FETCH_WRITABLE_PROGRAMS__FAILURE',
+    expect(fetchProgramsFailure).toBeInstanceOf(Function);
+    expect(fetchProgramsFailure({ foo: 'bar' })).toEqual({
+      type: 'GET__FETCH_PROGRAMS__FAILURE',
       payload: {
         error: { foo: 'bar' },
       },

--- a/src/upload/constants.js
+++ b/src/upload/constants.js
@@ -1,0 +1,8 @@
+
+// Permission codenames used in Registrar API.
+export const PERMISSIONS = { // eslint-disable-line import/prefer-default-export
+  readMetadata: 'read_metadata',
+  readEnrollments: 'read_enrollments',
+  writeEnrollments: 'write_enrollments',
+  readReports: 'read_reports',
+};

--- a/src/upload/reducers.js
+++ b/src/upload/reducers.js
@@ -1,4 +1,5 @@
-import { FETCH_WRITABLE_PROGRAMS } from './actions';
+import { FETCH_PROGRAMS } from './actions';
+import { shouldProgramBeDisplayed } from './utils';
 
 export const defaultState = {
   loading: false,
@@ -12,19 +13,20 @@ export const defaultState = {
 const upload = (state = defaultState, action) => {
   const { programBanners } = state;
   switch (action.type) {
-    case FETCH_WRITABLE_PROGRAMS.BEGIN:
+    case FETCH_PROGRAMS.BEGIN:
       return {
         ...state,
         loading: true,
         loaded: false,
         loadingError: null,
       };
-    case FETCH_WRITABLE_PROGRAMS.SUCCESS:
+    case FETCH_PROGRAMS.SUCCESS: {
+      const filteredData = action.payload.data.filter(shouldProgramBeDisplayed);
       return {
         ...state,
-        authorized: true,
-        data: action.payload.data,
-        programBanners: action.payload.data.reduce((acc, curVal) => {
+        authorized: filteredData.length > 0,
+        data: filteredData,
+        programBanners: filteredData.reduce((acc, curVal) => {
           acc[curVal.programKey] = [];
           return acc;
         }, {}),
@@ -32,7 +34,8 @@ const upload = (state = defaultState, action) => {
         loaded: false,
         loadingError: null,
       };
-    case FETCH_WRITABLE_PROGRAMS.FAILURE:
+    }
+    case FETCH_PROGRAMS.FAILURE:
       return {
         ...state,
         authorized: false,

--- a/src/upload/reducers.test.js
+++ b/src/upload/reducers.test.js
@@ -1,5 +1,5 @@
 import uploadReducer from './reducers';
-import { FETCH_WRITABLE_PROGRAMS } from './actions';
+import { FETCH_PROGRAMS } from './actions';
 
 describe('!upload reducer', () => {
   it('returns the initial state', () => {
@@ -13,9 +13,9 @@ describe('!upload reducer', () => {
     });
   });
 
-  describe('#FETCH_WRITABLE_PROGRAMS', () => {
-    it('...handles the GET__FETCH_WRITABLE_PROGRAMS__BEGIN action', () => {
-      expect(uploadReducer(undefined, { type: FETCH_WRITABLE_PROGRAMS.BEGIN })).toEqual({
+  describe('#FETCH_PROGRAMS', () => {
+    it('...handles the GET__FETCH_PROGRAMS__BEGIN action', () => {
+      expect(uploadReducer(undefined, { type: FETCH_PROGRAMS.BEGIN })).toEqual({
         loading: true,
         loaded: false,
         loadingError: null,
@@ -25,27 +25,49 @@ describe('!upload reducer', () => {
       });
     });
 
-    it('...handles the GET__FETCH_WRITABLE_PROGRAMS__SUCCESS action', () => {
-      const fetchWritableProgramSuccess = {
-        type: FETCH_WRITABLE_PROGRAMS.SUCCESS,
+    it('...handles the GET__FETCH_PROGRAMS__SUCCESS action with displayable programs', () => {
+      const fetchProgramSuccess = {
+        type: FETCH_PROGRAMS.SUCCESS,
         payload: {
           data: [
-            { programKey: '123' },
+            { programKey: '123', areEnrollmentsWritable: true },
+            { programKey: '456', areEnrollmentsWritable: false },
           ],
         },
       };
-      expect(uploadReducer(undefined, fetchWritableProgramSuccess)).toEqual({
+      expect(uploadReducer(undefined, fetchProgramSuccess)).toEqual({
         loading: true,
         loaded: false,
         loadingError: null,
         authorized: true,
-        data: [{ programKey: '123' }],
+        data: [
+          { programKey: '123', areEnrollmentsWritable: true },
+        ],
         programBanners: { 123: [] },
       });
     });
 
-    it('...handles the GET__FETCH_WRITABLE_PROGRAMS__FAILURE action', () => {
-      expect(uploadReducer(undefined, { type: FETCH_WRITABLE_PROGRAMS.FAILURE, payload: { error: 'oops!' } })).toEqual({
+    it('...handles the GET__FETCH_PROGRAMS__SUCCESS action without displayable programs', () => {
+      const fetchProgramSuccess = {
+        type: FETCH_PROGRAMS.SUCCESS,
+        payload: {
+          data: [
+            { programKey: '123', areEnrollmentsWritable: false },
+          ],
+        },
+      };
+      expect(uploadReducer(undefined, fetchProgramSuccess)).toEqual({
+        loading: true,
+        loaded: false,
+        loadingError: null,
+        authorized: false,
+        data: [],
+        programBanners: {},
+      });
+    });
+
+    it('...handles the GET__FETCH_PROGRAMS__FAILURE action', () => {
+      expect(uploadReducer(undefined, { type: FETCH_PROGRAMS.FAILURE, payload: { error: 'oops!' } })).toEqual({
         loading: false,
         loaded: false,
         loadingError: 'oops!',

--- a/src/upload/sagas.test.js
+++ b/src/upload/sagas.test.js
@@ -1,0 +1,86 @@
+/* Note that not all Sagas are tested.
+ * This is due to time constraints that existed when
+ * Program Manager was first developed.
+ *
+ * New Sagas will be tested here,
+ * and a good tech-debt item would be to
+ * add tests for existing Sagas.
+ */
+import { put } from 'redux-saga/effects';
+
+import {
+  fetchProgramsBegin,
+  fetchProgramsSuccess,
+  fetchJobs,
+  notAuthenticated,
+} from './actions';
+import { handleFetchPrograms } from './sagas';
+
+
+describe('handleFetchPrograms', () => {
+  function expectSagaBegin() {
+    const saga = handleFetchPrograms();
+    expect(saga.next().value).toEqual(put(fetchProgramsBegin()));
+    expect(saga.next().value.type).toEqual('CALL');
+    return saga;
+  }
+  function expectSagaEnd(saga) {
+    expect(saga.next().value).toEqual(put(fetchJobs()));
+    expect(saga.next().done).toBeTruthy();
+  }
+
+  it('...correctly fetches multiple programs.', () => {
+    const fakeApiResonse = [
+      {
+        program_key: 'a',
+        program_url: 'http://example.edu/a',
+        program_title: 'Program A',
+        permissions: ['read_metadata', 'write_enrollments', 'read_enrollments'],
+      },
+      {
+        program_key: 'b',
+        program_url: 'http://example.edu/b',
+        program_title: 'Program B',
+        permissions: ['read_metadata', 'read_reports'],
+      },
+    ];
+    const expectedResult = [
+      {
+        programKey: 'a',
+        programUrl: 'http://example.edu/a',
+        programTitle: 'Program A',
+        areEnrollmentsReadable: true,
+        areEnrollmentsWritable: true,
+        areReportsReadable: false,
+      },
+      {
+        programKey: 'b',
+        programUrl: 'http://example.edu/b',
+        programTitle: 'Program B',
+        areEnrollmentsReadable: false,
+        areEnrollmentsWritable: false,
+        areReportsReadable: true,
+      },
+    ];
+
+    const saga = expectSagaBegin();
+    expect(saga.next(fakeApiResonse).value)
+      .toEqual(put(fetchProgramsSuccess(expectedResult)));
+    expectSagaEnd(saga);
+  });
+
+  it('...correctly handles empty API resonse.', () => {
+    const saga = expectSagaBegin();
+    expect(saga.next([]).value)
+      .toEqual(put(notAuthenticated()));
+    expectSagaEnd(saga);
+  });
+
+  it('...correctly handles an unprocessable API resonse.', () => {
+    const saga = expectSagaBegin();
+    const fakeApiResonse = 'this API response will cause an exception';
+    expect(saga.next(fakeApiResonse).value.payload.action.type)
+      .toEqual('GET__FETCH_PROGRAMS__FAILURE');
+    expectSagaEnd(saga);
+  });
+});

--- a/src/upload/service.js
+++ b/src/upload/service.js
@@ -1,6 +1,7 @@
 import pick from 'lodash.pick';
 import { put } from 'redux-saga/effects';
 import { notAuthenticated } from './actions';
+import { PERMISSIONS } from './constants';
 
 let config = {
   REGISTRAR_API_BASE_URL: null,
@@ -22,8 +23,11 @@ export function configureApiService(newConfig, newApiClient) {
   apiClient = newApiClient;
 }
 
-export async function getWritablePrograms() {
-  const { data } = await apiClient.get(`${config.REGISTRAR_API_BASE_URL}/v1/programs/?user_has_perm=write`, {});
+export async function getAccessiblePrograms() {
+  const { data } = await apiClient.get(
+    `${config.REGISTRAR_API_BASE_URL}/v1/programs/?user_has_perm=${PERMISSIONS.readMetadata}`,
+    {},
+  );
   return data;
 }
 

--- a/src/upload/utils.js
+++ b/src/upload/utils.js
@@ -1,5 +1,5 @@
 
-export default function parseRegistrarJobName(registrarJobName) {
+export function parseRegistrarJobName(registrarJobName) {
   const jobNameRe = new RegExp('^(.+?):(.+?):(.+?)$');
   const parsedJobName = jobNameRe.exec(registrarJobName);
   if (parsedJobName === null) {
@@ -10,4 +10,13 @@ export default function parseRegistrarJobName(registrarJobName) {
     jobType: parsedJobName[2],
     jobName: parsedJobName[3],
   };
+}
+
+/* Return whether a program should be displayed on the UploadPage.
+ *
+ * For now, only display programs that are writable.
+ * In the future, this criteria will likely change.
+ */
+export function shouldProgramBeDisplayed(program) {
+  return program.areEnrollmentsWritable;
 }


### PR DESCRIPTION
Currently, we only load programs from Registrar for which the user has write-enrollments access.
Because we are soon adding report downloading to Program Manager, users with read-reports but NOT write-enrollments access must still see programs.

This PR lays the foundation by loading all programs via the API based on metadata access,
but continuing to only display programs with write-enrollments access.

@edx/masters-devs 
Ticket: https://openedx.atlassian.net/browse/MST-63

https://openedx.atlassian.net/browse/MST-82 must be deployed first.