### PR TITLE
Bug fix: Do not display collapsible in Reports section if no reports retrieved

### DIFF
--- a/src/report/__snapshots__/reportSection.test.jsx.snap
+++ b/src/report/__snapshots__/reportSection.test.jsx.snap
@@ -117,142 +117,24 @@ exports[`ReportSection component correctly passes isFirstSection prop to collaps
       >
         <div
           className="container"
-        />
+        >
+          <div>
+            <a
+              href="example.com/one-report"
+            >
+              one-report
+            </a>
+          </div>
+        </div>
       </div>
     </div>
   </div>
 </div>
 `;
 
-exports[`ReportSection component doesn't render contents when empty program key is passed in 1`] = `
-<div
-  className="pgn_collapsible shadow collapsible-card is-open"
-  open={undefined}
->
-  <div
-    aria-expanded={true}
-    className="collapsible-trigger"
-    onClick={[Function]}
-    onKeyDown={[Function]}
-    role="button"
-    tabIndex={0}
-  >
-    <span>
-      Download Reports
-    </span>
-    <span
-      className="ml-2"
-    >
-      <svg
-        aria-hidden="true"
-        className="svg-inline--fa fa-minus fa-w-14 "
-        data-icon="minus"
-        data-prefix="fas"
-        focusable="false"
-        role="img"
-        style={Object {}}
-        viewBox="0 0 448 512"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-          fill="currentColor"
-          style={Object {}}
-        />
-      </svg>
-    </span>
-  </div>
-  <div
-    className="pgn-transition-replace-group position-relative"
-    style={
-      Object {
-        "height": null,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "padding": ".1px 0",
-        }
-      }
-    >
-      <div
-        className="collapsible-body"
-      >
-        <div
-          className="container"
-        />
-      </div>
-    </div>
-  </div>
-</div>
-`;
+exports[`ReportSection component doesn't render contents when empty program key is passed in 1`] = `null`;
 
-exports[`ReportSection component doesn't render contents when no program data is passed in 1`] = `
-<div
-  className="pgn_collapsible shadow collapsible-card is-open"
-  open={undefined}
->
-  <div
-    aria-expanded={true}
-    className="collapsible-trigger"
-    onClick={[Function]}
-    onKeyDown={[Function]}
-    role="button"
-    tabIndex={0}
-  >
-    <span>
-      Download Reports
-    </span>
-    <span
-      className="ml-2"
-    >
-      <svg
-        aria-hidden="true"
-        className="svg-inline--fa fa-minus fa-w-14 "
-        data-icon="minus"
-        data-prefix="fas"
-        focusable="false"
-        role="img"
-        style={Object {}}
-        viewBox="0 0 448 512"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-          fill="currentColor"
-          style={Object {}}
-        />
-      </svg>
-    </span>
-  </div>
-  <div
-    className="pgn-transition-replace-group position-relative"
-    style={
-      Object {
-        "height": null,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "padding": ".1px 0",
-        }
-      }
-    >
-      <div
-        className="collapsible-body"
-      >
-        <div
-          className="container"
-        />
-      </div>
-    </div>
-  </div>
-</div>
-`;
+exports[`ReportSection component doesn't render contents when no program data is passed in 1`] = `null`;
 
 exports[`ReportSection component renders contents when program data is passed in 1`] = `
 <div
@@ -334,67 +216,4 @@ exports[`ReportSection component renders contents when program data is passed in
 </div>
 `;
 
-exports[`ReportSection component renders with the most basic props passed to it 1`] = `
-<div
-  className="pgn_collapsible shadow collapsible-card is-open"
-  open={undefined}
->
-  <div
-    aria-expanded={true}
-    className="collapsible-trigger"
-    onClick={[Function]}
-    onKeyDown={[Function]}
-    role="button"
-    tabIndex={0}
-  >
-    <span>
-      Download Reports
-    </span>
-    <span
-      className="ml-2"
-    >
-      <svg
-        aria-hidden="true"
-        className="svg-inline--fa fa-minus fa-w-14 "
-        data-icon="minus"
-        data-prefix="fas"
-        focusable="false"
-        role="img"
-        style={Object {}}
-        viewBox="0 0 448 512"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-          fill="currentColor"
-          style={Object {}}
-        />
-      </svg>
-    </span>
-  </div>
-  <div
-    className="pgn-transition-replace-group position-relative"
-    style={
-      Object {
-        "height": null,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "padding": ".1px 0",
-        }
-      }
-    >
-      <div
-        className="collapsible-body"
-      >
-        <div
-          className="container"
-        />
-      </div>
-    </div>
-  </div>
-</div>
-`;
+exports[`ReportSection component renders with the most basic props passed to it 1`] = `null`;

--- a/src/report/reportSection.jsx
+++ b/src/report/reportSection.jsx
@@ -19,20 +19,24 @@ export class ReportSection extends React.Component {
   }
 
   render() {
-    return (
-      <Collapsible
-        className="shadow"
-        title="Download Reports"
-        defaultOpen={this.props.isFirstSection}
-      >
-        <div className="container" key={`report-${this.props.programKey}`}>
-          {this.props.reportData[this.props.programKey] &&
-            this.props.reportData[this.props.programKey].map(report => (
-              <div key={report.name}><a href={report.downloadUrl}>{report.name}</a></div>
-          ))}
-        </div>
-      </Collapsible>
-    );
+    if (this.props.reportData[this.props.programKey] &&
+      this.props.reportData[this.props.programKey].length > 0) {
+      return (
+        <Collapsible
+          className="shadow"
+          title="Download Reports"
+          defaultOpen={this.props.isFirstSection}
+        >
+          <div className="container">
+            {
+              this.props.reportData[this.props.programKey].map(report => (
+                <div key={report.name}><a href={report.downloadUrl}>{report.name}</a></div>
+            ))}
+          </div>
+        </Collapsible>
+      );
+    }
+    return null;
   }
 }
 

--- a/src/report/reportSection.test.jsx
+++ b/src/report/reportSection.test.jsx
@@ -21,11 +21,19 @@ describe('ReportSection component', () => {
   });
 
   describe('correctly passes isFirstSection prop to collapsible component as defaultOpen', () => {
+    const reportData = {
+      'program-key': [
+        {
+          name: 'one-report',
+          downloadUrl: 'example.com/one-report',
+        },
+      ],
+    };
     [true, false].forEach((isFirstSectionValue) => {
       it(`${isFirstSectionValue}`, () => {
         const reportSectionComponent = (
           <ReportSection
-            reportData={{}}
+            reportData={reportData}
             fetchReports={() => { }}
             programKey="program-key"
             isFirstSection={isFirstSectionValue}
@@ -97,9 +105,7 @@ describe('ReportSection component', () => {
 
     expect(tree).toMatchSnapshot();
     const collapsible = wrapper.find(Collapsible);
-    assertCollapsibleProps(collapsible);
-
-    expect(collapsible.find('div.container').children()).toHaveLength(0);
+    expect(collapsible).toHaveLength(0);
   });
 
   it('doesn\'t render contents when empty program key is passed in', () => {
@@ -115,9 +121,7 @@ describe('ReportSection component', () => {
 
     expect(tree).toMatchSnapshot();
     const collapsible = wrapper.find(Collapsible);
-    assertCollapsibleProps(collapsible);
-
-    expect(collapsible.find('div.container').children()).toHaveLength(0);
+    expect(collapsible).toHaveLength(0);
   });
 
   it('calls the fetchReports function on load if program key prop is passed in', () => {


### PR DESCRIPTION
If the reports retrieved from the /api/v2/programs/<program_key>/reports call is an empty array, do not even render the empty collapsible. 

@edx/masters-devs Please review