### PR TITLE
limit the requested reports to the last seven days by using the minCr…

### DIFF
--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -79,3 +79,16 @@ export class AsyncActionType {
     return `${this.topic}__${this.name}__RESET`;
   }
 }
+
+export function getTodayWithDaysOffset(days) {
+  const date = new Date();
+  date.setDate(date.getDate() - days);
+  return date;
+}
+
+export function getISODateString(date) {
+  const isoDate = date.toISOString();
+  // we only want the date, not the time
+  const isoDateParts = isoDate.split('T');
+  return isoDateParts[0];
+}

--- a/src/common/utils.test.js
+++ b/src/common/utils.test.js
@@ -1,4 +1,13 @@
-import { AsyncActionType, modifyObjectKeys, camelCaseObject, snakeCaseObject, convertKeyNames, keepKeys } from './utils';
+import {
+  AsyncActionType,
+  modifyObjectKeys,
+  camelCaseObject,
+  snakeCaseObject,
+  convertKeyNames,
+  keepKeys,
+  getTodayWithDaysOffset,
+  getISODateString,
+} from './utils';
 
 describe('modifyObjectKeys', () => {
   it('should use the provided modify function to change all keys in and object and its children', () => {
@@ -113,6 +122,49 @@ describe('keepKeys', () => {
       expect(actionType.SUCCESS).toBe('HOUSE_CATS__START_THE_RACE__SUCCESS');
       expect(actionType.FAILURE).toBe('HOUSE_CATS__START_THE_RACE__FAILURE');
       expect(actionType.RESET).toBe('HOUSE_CATS__START_THE_RACE__RESET');
+    });
+  });
+
+  describe('getDateWithDaysOffset', () => {
+    let date;
+
+    beforeEach(() => {
+    });
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should return a correct date object for seven days ago', () => {
+      date = new Date(2020, 2, 15);
+      const sevenDaysAgo = new Date(2020, 2, 9);
+
+      jest.spyOn(global, 'Date').mockImplementationOnce(() => date);
+
+      expect(getTodayWithDaysOffset(6)).toEqual(sevenDaysAgo);
+    });
+
+    it('should return a correct date object for zero days ago', () => {
+      date = new Date(2020, 2, 15);
+      jest.spyOn(global, 'Date').mockImplementationOnce(() => date);
+
+      expect(getTodayWithDaysOffset(0)).toEqual(date);
+    });
+
+    it('should return a date with a correctly wrapped month and year', () => {
+      date = new Date(2020, 0, 1);
+      const sevenDaysAgo = new Date(2019, 11, 26);
+
+      jest.spyOn(global, 'Date').mockImplementationOnce(() => date);
+
+      expect(getTodayWithDaysOffset(6)).toEqual(sevenDaysAgo);
+    });
+  });
+
+  describe('getISODateString', () => {
+    it('should return an ISO Date string', () => {
+      const date = new Date(2020, 3, 5);
+      // months are zero-indexed
+      expect(getISODateString(date)).toEqual('2020-04-05');
     });
   });
 });

--- a/src/console/constants.js
+++ b/src/console/constants.js
@@ -6,3 +6,10 @@ export const PERMISSIONS = { // eslint-disable-line import/prefer-default-export
   writeEnrollments: 'write_enrollments',
   readReports: 'read_reports',
 };
+
+// The number of days counting back from today's date to use for
+// limiting the reports requested by their creation date.
+// Note that this is inclusive of the current date;
+// therefore, a value of 6 represents 7 days of reports.
+// This value should be 0 or a positive integer.
+export const REPORT_DATE_OFFSET_DAYS = 6;

--- a/src/report/service.js
+++ b/src/report/service.js
@@ -1,4 +1,6 @@
 import pick from 'lodash.pick';
+import { getTodayWithDaysOffset, getISODateString } from '../common/utils';
+import { REPORT_DATE_OFFSET_DAYS } from '../console/constants';
 
 let config = {
   REGISTRAR_API_BASE_URL: null,
@@ -21,10 +23,13 @@ export function configureApiService(newConfig, newApiClient) {
 }
 
 export async function getReportsByProgram(programKey) {
-  const { data } = await apiClient.get(
-    `${config.REGISTRAR_API_BASE_URL}/v1/programs/${programKey}/reports`,
-    {},
-  );
+  let url = `${config.REGISTRAR_API_BASE_URL}/v1/programs/${programKey}/reports`;
+
+  const minCreatedDate = getISODateString(getTodayWithDaysOffset(REPORT_DATE_OFFSET_DAYS));
+  url += `?min_created_date=${minCreatedDate}`;
+
+  const { data } = await apiClient.get(url, {});
+
   return data;
 }
 


### PR DESCRIPTION
…eatedDate query parameter on the reports API endpoint in registrar